### PR TITLE
make build reproducible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.build.outputTimestamp>2020-12-19T17:27:00Z</project.build.outputTimestamp>
         <jakartaee.version>10.0.0</jakartaee.version>
         <extra.excludes />
         <javadoc.options />
@@ -107,7 +108,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
-                    <useDefaultManifestFile>true</useDefaultManifestFile>
                     <archive>
                         <manifest>
                             <addClasspath>false</addClasspath>
@@ -196,7 +196,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -211,7 +211,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>2.1</version>
+                    <version>3.2.1</version>
                     <configuration>
                         <attach>true</attach>
                     </configuration>


### PR DESCRIPTION
see https://maven.apache.org/guides/mini/guide-reproducible-builds.html
this will permit to add the next release to https://github.com/jvm-repo-rebuild/reproducible-central

once eclipse-ee4j/ee4j#71 is merged and parent upgraded, the `project.build.outputTimestamp` will be updated automatically during release