### PR TITLE
Normalize core profile dependencies in web profile

### DIFF
--- a/jakartaee-api/pom.xml
+++ b/jakartaee-api/pom.xml
@@ -95,6 +95,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <sourcepath>${project.build.directory}/sources-dependency
+                        :../jakartaee-core-api/target/sources-dependency
                         :../jakartaee-web-api/target/sources-dependency</sourcepath>
                 </configuration>
             </plugin>
@@ -120,27 +121,32 @@
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-web-api</artifactId>
             <version>${project.version}</version>
-            <optional>false</optional>
+        </dependency>
+        <!-- Core Profile API -->
+        <!-- We specify it here directly, so it's "closer" in the dependency tree to the user app.
+             This way it will resolve the user's intended version via Maven's resolution mechanism,
+             and integrate well with other dependencies such as MicroProfile -->
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-core-api</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>jakarta.jms</groupId>
             <artifactId>jakarta.jms-api</artifactId>
             <version>${jakarta.jms-api.version}</version>
-            <optional>false</optional>
         </dependency>
         <dependency>
             <groupId>jakarta.activation</groupId>
             <artifactId>jakarta.activation-api</artifactId>
             <version>${jakarta.activation-api.version}</version>
-            <optional>false</optional>
         </dependency>
 
         <dependency>
             <groupId>jakarta.mail</groupId>
             <artifactId>jakarta.mail-api</artifactId>
             <version>${jakarta.mail-api.version}</version>
-            <optional>false</optional>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -152,7 +158,6 @@
             <groupId>jakarta.resource</groupId>
             <artifactId>jakarta.resource-api</artifactId>
             <version>${jakarta.resource-api.version}</version>
-            <optional>false</optional>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -164,7 +169,6 @@
             <groupId>jakarta.authorization</groupId>
             <artifactId>jakarta.authorization-api</artifactId>
             <version>${jakarta.authorization-api.version}</version>
-            <optional>false</optional>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -176,7 +180,6 @@
             <groupId>jakarta.batch</groupId>
             <artifactId>jakarta.batch-api</artifactId>
             <version>${jakarta.batch-api.version}</version>
-            <optional>false</optional>
              <exclusions>
                  <exclusion>
                      <groupId>*</groupId>

--- a/jakartaee-bom/pom.xml
+++ b/jakartaee-bom/pom.xml
@@ -181,7 +181,6 @@
                 <groupId>jakarta.enterprise</groupId>
                 <artifactId>jakarta.enterprise.cdi-api</artifactId>
                 <version>${jakarta.enterprise.cdi-api.version}</version>
-                <optional>false</optional>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -193,7 +192,6 @@
                 <groupId>jakarta.enterprise</groupId>
                 <artifactId>jakarta.enterprise.lang-model</artifactId>
                 <version>${jakarta.enterprise.cdi-api.version}</version>
-                <optional>false</optional>
             </dependency>
             <dependency>
                 <groupId>jakarta.inject</groupId>

--- a/jakartaee-core-api/pom.xml
+++ b/jakartaee-core-api/pom.xml
@@ -102,32 +102,27 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>${jakarta.ws.rs-api.cp.version}</version>
-            <optional>false</optional>
+            <version>${jakarta.ws.rs-api.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.json</groupId>
             <artifactId>jakarta.json-api</artifactId>
-            <version>${jakarta.json-api.cp.version}</version>
-            <optional>false</optional>
+            <version>${jakarta.json-api.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.json.bind</groupId>
             <artifactId>jakarta.json.bind-api</artifactId>
-            <version>${jakarta.json.bind-api.cp.version}</version>
-            <optional>false</optional>
+            <version>${jakarta.json.bind-api.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
-            <version>${jakarta.annotation-api.cp.version}</version>
-            <optional>false</optional>
+            <version>${jakarta.annotation-api.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.interceptor</groupId>
             <artifactId>jakarta.interceptor-api</artifactId>
-            <version>${jakarta.interceptor-api.cp.version}</version>
-            <optional>false</optional>
+            <version>${jakarta.interceptor-api.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -138,8 +133,7 @@
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
-            <version>${jakarta.enterprise.cdi-api.cp.version}</version>
-            <optional>false</optional>
+            <version>${jakarta.enterprise.cdi-api.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -150,14 +144,12 @@
         <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
-            <version>${jakarta.inject.cp.version}</version>
-            <optional>false</optional>
+            <version>${jakarta.inject.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.lang-model</artifactId>
-            <version>${jakarta.enterprise.cdi-api.cp.version}</version>
-            <optional>false</optional>
+            <version>${jakarta.enterprise.cdi-api.version}</version>
         </dependency>
 
         <!-- Only needed to compile the RESTful Link class as it uses XML Binding -->

--- a/jakartaee-web-api/pom.xml
+++ b/jakartaee-web-api/pom.xml
@@ -88,6 +88,14 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <sourcepath>${project.build.directory}/sources-dependency
+                        :../jakartaee-core-api/target/sources-dependency</sourcepath>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <executions>
                     <execution>
@@ -103,11 +111,16 @@
     </build>
 
     <dependencies>
+        <!-- Core Profile API  -->
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-core-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
             <version>${jakarta.servlet-api.version}</version>
-            <optional>false</optional>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -119,7 +132,6 @@
             <groupId>jakarta.servlet.jsp</groupId>
             <artifactId>jakarta.servlet.jsp-api</artifactId>
             <version>${jakarta.servlet.jsp-api.version}</version>
-            <optional>false</optional>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -127,17 +139,16 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Override from core profile to be non-optional and compiled scope -->
         <dependency>
             <groupId>jakarta.el</groupId>
             <artifactId>jakarta.el-api</artifactId>
             <version>${jakarta.el-api.version}</version>
-            <optional>false</optional>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet.jsp.jstl</groupId>
             <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
             <version>${jakarta.servlet.jsp.jstl-api.version}</version>
-            <optional>false</optional>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -149,7 +160,6 @@
             <groupId>jakarta.faces</groupId>
             <artifactId>jakarta.faces-api</artifactId>
             <version>${jakarta.faces-api.version}</version>
-            <optional>false</optional>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -158,46 +168,19 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>jakarta.ws.rs</groupId>
-            <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>${jakarta.ws.rs-api.version}</version>
-            <optional>false</optional>
-        </dependency>
-        <dependency>
             <groupId>jakarta.websocket</groupId>
             <artifactId>jakarta.websocket-api</artifactId>
             <version>${jakarta.websocket-api.version}</version>
-            <optional>false</optional>
         </dependency>
         <dependency>
             <groupId>jakarta.websocket</groupId>
             <artifactId>jakarta.websocket-client-api</artifactId>
             <version>${jakarta.websocket-api.version}</version>
-            <optional>false</optional>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.json</groupId>
-            <artifactId>jakarta.json-api</artifactId>
-            <version>${jakarta.json-api.version}</version>
-            <optional>false</optional>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.json.bind</groupId>
-            <artifactId>jakarta.json.bind-api</artifactId>
-            <version>${jakarta.json.bind-api.version}</version>
-            <optional>false</optional>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <version>${jakarta.annotation-api.version}</version>
-            <optional>false</optional>
         </dependency>
         <dependency>
             <groupId>jakarta.ejb</groupId>
             <artifactId>jakarta.ejb-api</artifactId>
             <version>${jakarta.ejb-api.version}</version>
-            <optional>false</optional>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -209,7 +192,6 @@
             <groupId>jakarta.transaction</groupId>
             <artifactId>jakarta.transaction-api</artifactId>
             <version>${jakarta.transaction-api.version}</version>
-            <optional>false</optional>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -221,61 +203,22 @@
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
             <version>${jakarta.persistence-api.version}</version>
-            <optional>false</optional>
         </dependency>
         <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
             <version>${jakarta.validation-api.version}</version>
-            <optional>false</optional>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.interceptor</groupId>
-            <artifactId>jakarta.interceptor-api</artifactId>
-            <version>${jakarta.interceptor-api.version}</version>
-            <optional>false</optional>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.enterprise</groupId>
-            <artifactId>jakarta.enterprise.cdi-api</artifactId>
-            <version>${jakarta.enterprise.cdi-api.version}</version>
-            <optional>false</optional>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.enterprise</groupId>
-            <artifactId>jakarta.enterprise.lang-model</artifactId>
-            <version>${jakarta.enterprise.cdi-api.version}</version>
-            <optional>false</optional>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.inject</groupId>
-            <artifactId>jakarta.inject-api</artifactId>
-            <version>${jakarta.inject.version}</version>
-            <optional>false</optional>
         </dependency>
         <dependency>
             <groupId>jakarta.authentication</groupId>
             <artifactId>jakarta.authentication-api</artifactId>
             <version>${jakarta.authentication-api.version}</version>
-            <optional>false</optional>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -287,7 +230,6 @@
             <groupId>jakarta.security.enterprise</groupId>
             <artifactId>jakarta.security.enterprise-api</artifactId>
             <version>${jakarta.security.enterprise-api.version}</version>
-            <optional>false</optional>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -299,21 +241,6 @@
             <groupId>jakarta.enterprise.concurrent</groupId>
             <artifactId>jakarta.enterprise.concurrent-api</artifactId>
             <version>${jakarta.enterprise.concurrent-api.version}</version>
-            <optional>false</optional>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <!-- This is an optional dependency of Jakarta RESTful Web Services -->
-        <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>${jakarta.xml.bind-api.version}</version>
-            <optional>true</optional>
-            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -341,6 +268,13 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <!-- Included only for Javadoc resolution (optional, non-transitive) -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>${jakarta.xml.bind-api.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>jakarta.xml.ws</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,14 +60,13 @@
 
 
         <!-- Core Profile -->
-        <!-- Theoretically these versions could be different from Web Profile -->
-        <jakarta.json-api.cp.version>2.1.0</jakarta.json-api.cp.version>
-        <jakarta.json.bind-api.cp.version>3.0.0</jakarta.json.bind-api.cp.version>
-        <jakarta.annotation-api.cp.version>2.1.1</jakarta.annotation-api.cp.version>
-        <jakarta.inject.cp.version>2.0.1</jakarta.inject.cp.version>
-        <jakarta.interceptor-api.cp.version>2.1.0</jakarta.interceptor-api.cp.version>
-        <jakarta.enterprise.cdi-api.cp.version>4.0.1</jakarta.enterprise.cdi-api.cp.version>
-        <jakarta.ws.rs-api.cp.version>3.1.0</jakarta.ws.rs-api.cp.version>
+        <jakarta.json-api.version>2.1.0</jakarta.json-api.version>
+        <jakarta.json.bind-api.version>3.0.0</jakarta.json.bind-api.version>
+        <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
+        <jakarta.inject.version>2.0.1</jakarta.inject.version>
+        <jakarta.interceptor-api.version>2.1.0</jakarta.interceptor-api.version>
+        <jakarta.enterprise.cdi-api.version>4.0.1</jakarta.enterprise.cdi-api.version>
+        <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
 
         <!-- Web Profile -->
         <jakarta.servlet-api.version>6.0.0</jakarta.servlet-api.version>
@@ -76,19 +75,12 @@
         <jakarta.faces-api.version>4.0.1</jakarta.faces-api.version>
         <jakarta.el-api.version>5.0.1</jakarta.el-api.version>
         <jakarta.websocket-api.version>2.1.0</jakarta.websocket-api.version>
-        <jakarta.json-api.version>2.1.0</jakarta.json-api.version>
-        <jakarta.json.bind-api.version>3.0.0</jakarta.json.bind-api.version>
-        <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
         <jakarta.ejb-api.version>4.0.1</jakarta.ejb-api.version>
         <jakarta.transaction-api.version>2.0.1</jakarta.transaction-api.version>
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
         <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>
-        <jakarta.interceptor-api.version>2.1.0</jakarta.interceptor-api.version>
-        <jakarta.enterprise.cdi-api.version>4.0.1</jakarta.enterprise.cdi-api.version>
-        <jakarta.inject.version>2.0.1</jakarta.inject.version>
         <jakarta.authentication-api.version>3.0.0</jakarta.authentication-api.version>
         <jakarta.security.enterprise-api.version>3.0.0</jakarta.security.enterprise-api.version>
-        <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
         <jakarta.enterprise.concurrent-api.version>3.0.1</jakarta.enterprise.concurrent-api.version>
         
         <!--  Full platform -->
@@ -262,7 +254,7 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.1.0</version>
                     <configuration>
-                        <failOnError>false</failOnError>
+                        <failOnError>true</failOnError>
                         <additionalJOptions>${javadoc.options}</additionalJOptions>
                         <docfilessubdirs>true</docfilessubdirs>
                         <javadocDirectory>${project.basedir}/../src/main/javadoc</javadocDirectory>


### PR DESCRIPTION
## Summary
Conclusion of #133 Bug fix train
Makes Core profile a true dependency of Web profile and plays nice with MicroProfile POM
fixes #138 

## Goals
* Make `jakartaee-api` and `jakartaee-web-api` depend on `jakartaee-core-api` to be consistent with maven resolution rules, and thus make it intuitive to application both app devs and MicroProfile.
* Remove `*-api.cp.version` properties, as they are now overridable with 'regular' maven pom directives, and thus no longer necessary. 
* Remove duplicate dependencies from `jakartaee-web-api` that are already in `jakartaee-core-api` (this can now be done safely because empty JARs are now shipped.
* Make the minimum changes necessary to accomplish the goal.
* Make this suitable as a patch release for Jakarta EE 10 (ex: 10.0.1)
* Remove unnecessary `<optional>` tags from POMs
* Preserve generation of javadoc as it is now (jakarta-api includes platrorm, web and core javadocs, jakartaee-web-api includes web and core javadocs, etc)
* Make javadoc generation errors fail the build. Otherwise, they fail silently generating invalid javadocs (possibly leading to invalid releases)

## Non-Goals
* Not intended as a complete refactoring of the POM files

