### PR TITLE
Provide modularized view of the APIs in the javadocs

### DIFF
--- a/jakartaee-api/pom.xml
+++ b/jakartaee-api/pom.xml
@@ -222,18 +222,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>jakarta.enterprise.concurrent</groupId>
-            <artifactId>jakarta.enterprise.concurrent-api</artifactId>
-            <version>${jakarta.enterprise.concurrent-api.version}</version>
-            <optional>true</optional>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+
         <!-- Compile-time dependencies -->
         <!-- work around for GLASSFISH-19861  -->
         <dependency>

--- a/jakartaee-api/pom.xml
+++ b/jakartaee-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>jakarta.platform</groupId>
         <artifactId>jakartaee-api-parent</artifactId>
-        <version>10.0.0-SNAPSHOT</version>
+        <version>11.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>jakarta.jakartaee-api</artifactId>
     <name>Jakarta EE Platform API</name>

--- a/jakartaee-api/pom.xml
+++ b/jakartaee-api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -28,8 +28,44 @@
     <name>Jakarta EE Platform API</name>
     <description>Jakarta EE Platform API</description>
 
+    <properties>
+        <apidocs.optional>jakarta.xml.bind*,jakarta.xml.soap*,jakarta.xml.ws*</apidocs.optional>
+    </properties>
+
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-sources</id>
+                        <phase>generate-sources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>prepare-sources</id>
+                        <phase>process-sources</phase>
+                    </execution>
+                    <execution>
+                        <id>prepare-sources-web</id>
+                        <phase>process-sources</phase>
+                    </execution>
+                    <execution>
+                        <id>prepare-sources-platform</id>
+                        <phase>process-sources</phase>
+                    </execution>
+                    <execution>
+                        <id>build-javadocs</id>
+                        <phase>compile</phase>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.glassfish.build</groupId>
                 <artifactId>glassfishbuild-maven-plugin</artifactId>
@@ -186,7 +222,18 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
+        <dependency>
+            <groupId>jakarta.enterprise.concurrent</groupId>
+            <artifactId>jakarta.enterprise.concurrent-api</artifactId>
+            <version>${jakarta.enterprise.concurrent-api.version}</version>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <!-- Compile-time dependencies -->
         <!-- work around for GLASSFISH-19861  -->
         <dependency>

--- a/jakartaee-bom/pom.xml
+++ b/jakartaee-bom/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>jakarta.platform</groupId>
         <artifactId>jakartaee-api-parent</artifactId>
-        <version>10.0.0-SNAPSHOT</version>
+        <version>11.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>jakarta.jakartaee-bom</artifactId>
     <packaging>pom</packaging>

--- a/jakartaee-core-api/pom.xml
+++ b/jakartaee-core-api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2022, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -28,8 +28,36 @@
     <name>Jakarta EE Core Profile API</name>
     <description>Jakarta EE Core Profile API</description>
 
+    <properties>
+        <apidocs.modulepath>${jakarta.activation:jakarta.activation-api:jar}:${jakarta.xml.bind:jakarta.xml.bind-api:jar}:${jakarta.el:jakarta.el-api:jar}</apidocs.modulepath>
+    </properties>
+
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-sources</id>
+                        <phase>generate-sources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>prepare-sources</id>
+                        <phase>process-sources</phase>
+                    </execution>
+                    <execution>
+                        <id>build-javadocs</id>
+                        <phase>compile</phase>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.glassfish.build</groupId>
                 <artifactId>glassfishbuild-maven-plugin</artifactId>
@@ -137,6 +165,19 @@
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
             <version>${jakarta.xml.bind-api.version}</version>
+            <optional>true</optional>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+            <version>${jakarta.activation-api.version}</version>
             <optional>true</optional>
             <scope>provided</scope>
             <exclusions>

--- a/jakartaee-core-api/pom.xml
+++ b/jakartaee-core-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>jakarta.platform</groupId>
         <artifactId>jakartaee-api-parent</artifactId>
-        <version>10.0.0-SNAPSHOT</version>
+        <version>11.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>jakarta.jakartaee-core-api</artifactId>
     <name>Jakarta EE Core Profile API</name>

--- a/jakartaee-web-api/pom.xml
+++ b/jakartaee-web-api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -28,8 +28,40 @@
     <name>Jakarta EE Web Profile API</name>
     <description>Jakarta EE Web Profile API</description>
 
+    <properties>
+        <apidocs.modulepath>${jakarta.activation:jakarta.activation-api:jar}:${jakarta.xml.bind:jakarta.xml.bind-api:jar}:${jakarta.xml.soap:jakarta.xml.soap-api:jar}:${jakarta.xml.ws:jakarta.xml.ws-api:jar}:${jakarta.el:jakarta.el-api:jar}</apidocs.modulepath>
+    </properties>
+
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-sources</id>
+                        <phase>generate-sources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>prepare-sources</id>
+                        <phase>process-sources</phase>
+                    </execution>
+                    <execution>
+                        <id>prepare-sources-web</id>
+                        <phase>process-sources</phase>
+                    </execution>
+                    <execution>
+                        <id>build-javadocs</id>
+                        <phase>compile</phase>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.glassfish.build</groupId>
                 <artifactId>glassfishbuild-maven-plugin</artifactId>
@@ -267,7 +299,7 @@
             <groupId>jakarta.enterprise.concurrent</groupId>
             <artifactId>jakarta.enterprise.concurrent-api</artifactId>
             <version>${jakarta.enterprise.concurrent-api.version}</version>
-            <optional>true</optional>
+            <optional>false</optional>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -301,6 +333,32 @@
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.faces</artifactId>
             <version>${mojarra.version}</version>
+            <optional>true</optional>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
+            <version>${jakarta.xml.ws-api.version}</version>
+            <optional>true</optional>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.soap</groupId>
+            <artifactId>jakarta.xml.soap-api</artifactId>
+            <version>${jakarta.xml.soap-api.version}</version>
             <optional>true</optional>
             <scope>provided</scope>
             <exclusions>

--- a/jakartaee-web-api/pom.xml
+++ b/jakartaee-web-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>jakarta.platform</groupId>
         <artifactId>jakartaee-api-parent</artifactId>
-        <version>10.0.0-SNAPSHOT</version>
+        <version>11.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>jakarta.jakartaee-web-api</artifactId>
     <name>Jakarta EE Web Profile API</name>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -43,6 +43,21 @@
         <jakartaee.version>10.0.0</jakartaee.version>
         <extra.excludes />
         <javadoc.options />
+
+        <apidocs.api.src>${project.build.directory}/api-sources</apidocs.api.src>
+        <apidocs.api.tmp>${project.build.directory}/api-sources-tmp</apidocs.api.tmp>
+        <apidocs.api.dist>${project.build.directory}/api-javadoc</apidocs.api.dist>
+        <apidocs.modulepath/>
+        <apidocs.required>*</apidocs.required>
+        <apidocs.optional/>
+
+        <apidocs.windowtitle>${project.name}</apidocs.windowtitle>
+        <apidocs.doctitle>${project.name}</apidocs.doctitle>
+        <apidocs.header><![CDATA[<br>${project.name} v${project.version}]]></apidocs.header>
+        <apidocs.bottom><![CDATA[
+<p align="left">Copyright &#169; 2018,2023 Eclipse Foundation.<br>Use is subject to
+<a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.]]></apidocs.bottom>
+
 
         <!-- Core Profile -->
         <!-- Theoretically these versions could be different from Web Profile -->
@@ -93,7 +108,7 @@
         <copyright-plugin.version>1.50</copyright-plugin.version>
 
         <!-- Compile-time dependencies -->
-        <mojarra.version>4.0.0</mojarra.version>
+        <mojarra.version>4.0.1</mojarra.version>
         
         <!-- Java compiler release (replaces source and target)-->
         <maven.compiler.release>11</maven.compiler.release>
@@ -245,7 +260,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.5.0</version>
                     <configuration>
                         <failOnError>false</failOnError>
                         <additionalJOptions>${javadoc.options}</additionalJOptions>
@@ -253,16 +268,223 @@
                         <javadocDirectory>${project.basedir}/../src/main/javadoc</javadocDirectory>
                         <attach>true</attach>
                         <doclint>none</doclint>
-                        <doctitle>${project.name}</doctitle>
-                        <windowtitle>${project.name}</windowtitle>
-                        <header><![CDATA[<br>${project.name} v${project.version}]]></header>
-                        <bottom>
-<![CDATA[
-<p align="left">Copyright &#169; 2018,2023 Eclipse Foundation.<br>Use is subject to
-<a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.]]>
-                        </bottom>
+                        <doctitle>${apidocs.doctitle}</doctitle>
+                        <windowtitle>${apidocs.windowtitle}</windowtitle>
+                        <header>${apidocs.header}</header>
+                        <bottom>${apidocs.bottom}</bottom>
                         <sourcepath>${project.build.directory}/sources-dependency</sourcepath>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>3.6.0</version>
+                    <executions>
+                        <execution>
+                            <id>unpack-sources</id>
+                            <phase>none</phase>
+                            <goals>
+                                <goal>unpack-dependencies</goal>
+                            </goals>
+                            <configuration>
+                                <outputDirectory>${apidocs.api.tmp}</outputDirectory>
+                                <classifier>sources</classifier>
+                                <useSubDirectoryPerArtifact>true</useSubDirectoryPerArtifact>
+                                <stripVersion>true</stripVersion>
+                                <excludeScope>provided</excludeScope>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>3.1.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.ant</groupId>
+                            <artifactId>ant</artifactId>
+                            <version>1.10.12</version>
+                        </dependency>
+                    </dependencies>
+                    <executions>
+                        <execution>
+                            <id>prepare-sources</id>
+                            <phase>none</phase>
+                            <goals>
+                                <goal>run</goal>
+                            </goals>
+                            <configuration>
+                                <target>
+                                    <mkdir dir="${apidocs.api.src}"/>
+                                    <copy todir="${apidocs.api.src}" >
+                                        <fileset dir="${apidocs.api.tmp}">
+                                            <include name="*-api-sources-jar/**"/>
+                                            <exclude name="jakarta.enterprise.cdi-api-sources-jar/**"/>
+                                            <!-- web-profile -->
+                                            <exclude name="jakarta.authentication-api-sources-jar/**"/>
+                                            <exclude name="jakarta.enterprise.concurrent-api-sources-jar/**"/>
+                                            <exclude name="jakarta.security.enterprise-api-sources-jar/**"/>
+                                            <exclude name="jakarta.websocket-client-api-sources-jar/**"/>
+                                            <!-- full -->
+                                            <exclude name="jakarta.authorization-api-sources-jar/**"/>
+                                            <exclude name="jakarta.jms-api-sources-jar/**"/>
+                                        </fileset>
+                                        <mapper type="regexp" from="^(.*)-api-sources-jar(.*)$$" to="\1\2"/>
+                                    </copy>
+
+                                    <copy todir="${apidocs.api.src}/jakarta.cdi" >
+                                        <fileset dir="${apidocs.api.tmp}/jakarta.enterprise.cdi-api-sources-jar">
+                                            <include name="**/*"/>
+                                        </fileset>
+                                    </copy>
+                                    <copy todir="${apidocs.api.src}/jakarta.cdi.lang.model" >
+                                        <fileset dir="${apidocs.api.tmp}/jakarta.enterprise.lang-model-sources-jar">
+                                            <include name="**/*"/>
+                                        </fileset>
+                                    </copy>
+                                </target>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>prepare-sources-web</id>
+                            <phase>none</phase>
+                            <goals>
+                                <goal>run</goal>
+                            </goals>
+                            <configuration>
+                                <target>
+                                    <copy todir="${apidocs.api.src}/jakarta.security.auth.message" >
+                                        <fileset dir="${apidocs.api.tmp}/jakarta.authentication-api-sources-jar">
+                                            <include name="**/*"/>
+                                        </fileset>
+                                    </copy>
+                                    <copy todir="${apidocs.api.src}/jakarta.concurrency" >
+                                        <fileset dir="${apidocs.api.tmp}/jakarta.enterprise.concurrent-api-sources-jar">
+                                            <include name="**/*"/>
+                                        </fileset>
+                                    </copy>
+                                    <copy todir="${apidocs.api.src}/jakarta.security" >
+                                        <fileset dir="${apidocs.api.tmp}/jakarta.security.enterprise-api-sources-jar">
+                                            <include name="**/*"/>
+                                        </fileset>
+                                    </copy>
+                                    <copy todir="${apidocs.api.src}/jakarta.websocket.client" >
+                                        <fileset dir="${apidocs.api.tmp}/jakarta.websocket-client-api-sources-jar">
+                                            <include name="**/*"/>
+                                        </fileset>
+                                    </copy>
+
+                                    <echo file="${apidocs.api.src}/jakarta.faces/module-info.java">
+module jakarta.faces {
+    exports jakarta.faces;
+    exports jakarta.faces.annotation;
+    exports jakarta.faces.application;
+    exports jakarta.faces.component;
+    exports jakarta.faces.component.behavior;
+    exports jakarta.faces.component.html;
+    exports jakarta.faces.component.search;
+    exports jakarta.faces.component.visit;
+    exports jakarta.faces.context;
+    exports jakarta.faces.convert;
+    exports jakarta.faces.el;
+    exports jakarta.faces.event;
+    exports jakarta.faces.flow;
+    exports jakarta.faces.flow.builder;
+    exports jakarta.faces.lifecycle;
+    exports jakarta.faces.model;
+    exports jakarta.faces.push;
+    exports jakarta.faces.render;
+    exports jakarta.faces.validator;
+    exports jakarta.faces.view;
+    exports jakarta.faces.view.facelets;
+    exports jakarta.faces.webapp;
+
+    requires java.logging;
+    requires jakarta.el;
+    requires jakarta.cdi;
+    requires jakarta.servlet;
+    requires jakarta.validation;
+    requires jakarta.websocket;
+    requires jakarta.websocket.client;
+    requires java.desktop;
+    requires java.sql;
+    requires java.naming;
+    requires jakarta.inject;
+    requires jakarta.persistence;
+    requires jakarta.ejb;
+    requires jakarta.json;
+    requires jakarta.xml.ws;
+}
+                                    </echo>
+                                </target>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>prepare-sources-platform</id>
+                            <phase>none</phase>
+                            <goals>
+                                <goal>run</goal>
+                            </goals>
+                            <configuration>
+                                <target>
+                                    <copy todir="${apidocs.api.src}/jakarta.security.jacc" >
+                                        <fileset dir="${apidocs.api.tmp}/jakarta.authorization-api-sources-jar">
+                                            <include name="**/*"/>
+                                        </fileset>
+                                    </copy>
+
+                                    <copy todir="${apidocs.api.src}/jakarta.messaging" >
+                                        <fileset dir="${apidocs.api.tmp}/jakarta.jms-api-sources-jar">
+                                            <include name="**/*"/>
+                                        </fileset>
+                                    </copy>
+                                </target>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>build-javadocs</id>
+                            <phase>none</phase>
+                            <goals>
+                                <goal>run</goal>
+                            </goals>
+                            <configuration>
+                                <target>
+                                    <mkdir dir="${apidocs.api.dist}"/>
+                                    <javadoc destdir="${apidocs.api.dist}"
+                                             modulesourcepath="${apidocs.api.src}"
+                                             modulepath="${apidocs.modulepath}"
+                                             author="false"
+                                             docfilessubdirs="true"
+                                             failonerror="true"
+                                             serialwarn="true"
+                                             source="${maven.compiler.release}"
+                                             splitindex="true"
+                                             use="true"
+                                             windowtitle="${apidocs.windowtitle}"
+                                    >
+                                        <arg value="-J-Xmx256m"/>
+                                        <arg value="-Xdoclint:none"/>
+                                        <arg value="-notimestamp"/>
+                                        <arg value="-quiet"/>
+                                        <doctitle>${apidocs.doctitle}</doctitle>
+                                        <bottom>${apidocs.bottom}</bottom>
+                                        <header>${apidocs.header}</header>
+                                        <group title="Required Modules" packages="${apidocs.required}"/>
+                                        <group title="Optional Modules" packages="${apidocs.optional}"/>
+                                        <fileset dir="${apidocs.api.src}">
+                                            <include name="**/*.java"/>
+                                        </fileset>
+                                    </javadoc>
+                                    <copy todir="${apidocs.api.dist}" >
+                                        <fileset dir="${project.basedir}/../src/main/javadoc">
+                                            <include name="**/*"/>
+                                        </fileset>
+                                    </copy>
+                                </target>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <copyright-plugin.version>1.50</copyright-plugin.version>
 
         <!-- Compile-time dependencies -->
-        <mojarra.version>4.0.1</mojarra.version>
+        <mojarra.version>4.0.0</mojarra.version>
         
         <!-- Java compiler release (replaces source and target)-->
         <maven.compiler.release>11</maven.compiler.release>
@@ -260,7 +260,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>3.1.0</version>
                     <configuration>
                         <failOnError>false</failOnError>
                         <additionalJOptions>${javadoc.options}</additionalJOptions>
@@ -433,7 +433,6 @@ module jakarta.faces {
                                             <include name="**/*"/>
                                         </fileset>
                                     </copy>
-
                                     <copy todir="${apidocs.api.src}/jakarta.messaging" >
                                         <fileset dir="${apidocs.api.tmp}/jakarta.jms-api-sources-jar">
                                             <include name="**/*"/>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
     <groupId>jakarta.platform</groupId>
     <artifactId>jakartaee-api-parent</artifactId>
-    <version>10.0.0-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Jakarta EE API parent</name>
     <description>Jakarta EE API parent</description>


### PR DESCRIPTION
Given all specs included in the platform are expected to define module info, the javadoc of the platform and profiles should reflect that. The modular view also allows one the express optionality of some parts (see the Platform javadoc, pointer is bellow)

Compare:
* [Current Core Profile javadoc](https://jakarta.ee/specifications/coreprofile/10/apidocs/) with [corresponding modular view](https://deploy-preview-1--imaginative-lamington-97e4b1.netlify.app/specifications/coreprofile/10/apidocs/)
* [Current Web Profile javadoc](https://jakarta.ee/specifications/webprofile/10/apidocs/) with [corresponding modular view](https://deploy-preview-1--imaginative-lamington-97e4b1.netlify.app/specifications/webprofile/10/apidocs/)
* [Current Platform javadoc](https://jakarta.ee/specifications/platform/10/apidocs/) with [corresponding modular view](https://deploy-preview-1--imaginative-lamington-97e4b1.netlify.app/specifications/platform/10/apidocs/)

This PR also reveals following issues:
* profiles have build-time dependencies on not included specs - probably interesting for @JanWesterkamp-iJUG 
* web profile defines Jakarta Concurrency as `<optional>true</optional>` which means that `jakarta.jakartaee-api` artifact does not see it - this PR fixes this by changing optionality to `false`
* 8 artifacts do not follow the convention of mapping artifactId to Java Module name - something I can live with, so just saying
* `jakarta.faces` is the only artifact not providing JPMS descriptor - there's one (quick & dirty) being produced by the javadoc build in this PR just to be able to provide full and valid modular javadoc itself - can be interesting for @arjantijms
* only few modules have some description - can be good issue for the platform to define the pattern to use and for the community to provide PRs to apply the pattern accross specs 

Last but not least this fixes https://github.com/jakartaee/jakartaee-platform/issues/676