### PR TITLE
Enhancement: allow to deploy parent from command line

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <jakartaee.version>11.0.0</jakartaee.version>
         <extra.excludes />
         <javadoc.options />
+        <parent.deploy.skip>true</parent.deploy.skip>
 
         <apidocs.api.src>${project.build.directory}/api-sources</apidocs.api.src>
         <apidocs.api.tmp>${project.build.directory}/api-sources-tmp</apidocs.api.tmp>
@@ -175,7 +176,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <configuration>
-                    <skip>true</skip>
+                    <skip>${parent.deploy.skip}</skip>
                 </configuration>
                 <inherited>false</inherited>
             </plugin>


### PR DESCRIPTION
Currently, there is no way to deploy api-parent to repository other than using the maven staging plugin.
When testing, a 'regular' deploy is needed via deploy plugin, without the staging plugin.

This PR refactor the deployment skip into a variable so it can be set on the command line.

Fixes #145