### PR TITLE
enh: removed optional APIs no longer in Jakarta EE 11: xml, soap

### DIFF
--- a/jakartaee-api/pom.xml
+++ b/jakartaee-api/pom.xml
@@ -28,10 +28,6 @@
     <name>Jakarta EE Platform API</name>
     <description>Jakarta EE Platform API</description>
 
-    <properties>
-        <apidocs.optional>jakarta.xml.bind*,jakarta.xml.soap*,jakarta.xml.ws*</apidocs.optional>
-    </properties>
-
     <build>
         <plugins>
             <plugin>
@@ -186,44 +182,6 @@
                      <artifactId>*</artifactId>
                  </exclusion>
              </exclusions>
-        </dependency>
-
-        <!-- Optional APIs -->
-        <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>${jakarta.xml.bind-api.version}</version>
-            <optional>true</optional>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.xml.ws</groupId>
-            <artifactId>jakarta.xml.ws-api</artifactId>
-            <version>${jakarta.xml.ws-api.version}</version>
-            <optional>true</optional>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.xml.soap</groupId>
-            <artifactId>jakarta.xml.soap-api</artifactId>
-            <version>${jakarta.xml.soap-api.version}</version>
-            <optional>true</optional>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- Compile-time dependencies -->

--- a/jakartaee-bom/pom.xml
+++ b/jakartaee-bom/pom.xml
@@ -298,42 +298,6 @@
                      </exclusion>
                  </exclusions>
             </dependency>
-
-            <!-- Optional APIs -->
-            <dependency>
-                <groupId>jakarta.xml.bind</groupId>
-                <artifactId>jakarta.xml.bind-api</artifactId>
-                <version>${jakarta.xml.bind-api.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.xml.ws</groupId>
-                <artifactId>jakarta.xml.ws-api</artifactId>
-                <version>${jakarta.xml.ws-api.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.xml.soap</groupId>
-                <artifactId>jakarta.xml.soap-api</artifactId>
-                <version>${jakarta.xml.soap-api.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
         </dependencies>
     </dependencyManagement>
 </project>

--- a/jakartaee-core-api/pom.xml
+++ b/jakartaee-core-api/pom.xml
@@ -152,20 +152,6 @@
             <version>${jakarta.enterprise.cdi-api.version}</version>
         </dependency>
 
-        <!-- Only needed to compile the RESTful Link class as it uses XML Binding -->
-        <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>${jakarta.xml.bind-api.version}</version>
-            <optional>true</optional>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
         <dependency>
             <groupId>jakarta.activation</groupId>
             <artifactId>jakarta.activation-api</artifactId>

--- a/jakartaee-web-api/pom.xml
+++ b/jakartaee-web-api/pom.xml
@@ -279,37 +279,5 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- Included only for Javadoc resolution (optional, non-transitive) -->
-        <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>${jakarta.xml.bind-api.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.xml.ws</groupId>
-            <artifactId>jakarta.xml.ws-api</artifactId>
-            <version>${jakarta.xml.ws-api.version}</version>
-            <optional>true</optional>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.xml.soap</groupId>
-            <artifactId>jakarta.xml.soap-api</artifactId>
-            <version>${jakarta.xml.soap-api.version}</version>
-            <optional>true</optional>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,6 @@
         <apidocs.api.dist>${project.build.directory}/api-javadoc</apidocs.api.dist>
         <apidocs.modulepath/>
         <apidocs.required>*</apidocs.required>
-        <apidocs.optional/>
-
         <apidocs.windowtitle>${project.name}</apidocs.windowtitle>
         <apidocs.doctitle>${project.name}</apidocs.doctitle>
         <apidocs.header><![CDATA[<br>${project.name} v${project.version}]]></apidocs.header>
@@ -93,11 +91,6 @@
         <jakarta.resource-api.version>2.1.0</jakarta.resource-api.version>
         <jakarta.authorization-api.version>3.0.0</jakarta.authorization-api.version>
         <jakarta.batch-api.version>2.1.1</jakarta.batch-api.version>
-
-        <!-- Optional APIs Plan to remove in EE 11 M3. -->
-        <jakarta.xml.bind-api.version>4.0.1</jakarta.xml.bind-api.version>
-        <jakarta.xml.ws-api.version>4.0.1</jakarta.xml.ws-api.version>
-        <jakarta.xml.soap-api.version>3.0.1</jakarta.xml.soap-api.version>
 
         <!-- Other dependencies -->
         <copyright-plugin.version>1.50</copyright-plugin.version>
@@ -381,8 +374,31 @@
                                         </fileset>
                                     </copy>
 
+                                    <delete file="${apidocs.api.src}/jakarta.faces/com/sun/faces/application/annotation/DelegatedWebServiceRefScanner.java"/>
+                                    <delete file="${apidocs.api.src}/jakarta.faces/com/sun/faces/application/annotation/WebServiceRefHandler.java"/>
+                                    <delete file="${apidocs.api.src}/jakarta.faces/com/sun/faces/application/annotation/WebServiceRefScanner.java"/>
+
+                                    <!-- Below is a Workaround for https://github.com/jakartaee/faces/issues/1913 (jax-ws require removed) -->
                                     <echo file="${apidocs.api.src}/jakarta.faces/module-info.java">
 module jakarta.faces {
+    requires jakarta.inject;
+    requires jakarta.validation;
+    requires java.logging;
+    requires java.naming;
+
+    requires static jakarta.cdi;
+    requires static jakarta.cdi.el;
+    requires static jakarta.el;
+    requires static jakarta.servlet;
+    requires static jakarta.websocket.client;
+    requires static jakarta.websocket;
+    requires static jakarta.persistence;
+    requires static jakarta.ejb;
+    requires static jakarta.json;
+    requires transitive java.desktop;
+    requires transitive java.sql;
+    requires transitive java.xml;
+
     exports jakarta.faces;
     exports jakarta.faces.annotation;
     exports jakarta.faces.application;
@@ -405,23 +421,6 @@ module jakarta.faces {
     exports jakarta.faces.view;
     exports jakarta.faces.view.facelets;
     exports jakarta.faces.webapp;
-
-    requires java.logging;
-    requires jakarta.el;
-    requires jakarta.cdi;
-    requires jakarta.cdi.el;
-    requires jakarta.servlet;
-    requires jakarta.validation;
-    requires jakarta.websocket;
-    requires jakarta.websocket.client;
-    requires java.desktop;
-    requires java.sql;
-    requires java.naming;
-    requires jakarta.inject;
-    requires jakarta.persistence;
-    requires jakarta.ejb;
-    requires jakarta.json;
-    requires jakarta.xml.ws;
 }
                                     </echo>
                                 </target>
@@ -445,21 +444,6 @@ module jakarta.faces {
                                             <include name="**/*"/>
                                         </fileset>
                                     </copy>
-                                </target>
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <!-- workaround for error: package jakarta.xml.ws.wsaddressing has already been annotated @jakarta.xml.bind.annotation.XmlSchema(namespace=W3CEndpointReference.NS, -->
-                            <id>rewrite-problematic-sources</id>
-                            <phase>prepare-package</phase>
-                            <goals>
-                                <goal>run</goal>
-                            </goals>
-                            <configuration>
-                                <target>
-                                    <echo file="${project.build.directory}/sources-dependency/jakarta/xml/ws/wsaddressing/package-info.java"
-                                          message="package jakarta.xml.ws.wsaddressing;${line.separator}"
-                                          append="false" />
                                 </target>
                             </configuration>
                         </execution>
@@ -492,7 +476,6 @@ module jakarta.faces {
                                         <bottom>${apidocs.bottom}</bottom>
                                         <header>${apidocs.header}</header>
                                         <group title="Required Modules" packages="${apidocs.required}"/>
-                                        <group title="Optional Modules" packages="${apidocs.optional}"/>
                                         <fileset dir="${apidocs.api.src}">
                                             <include name="**/*.java"/>
                                         </fileset>


### PR DESCRIPTION
fixes #162 

Includes a workaround for https://github.com/jakartaee/faces/issues/1913