### PR TITLE
Prepare next development cycle for 10.0.1-SNAPSHOT

### DIFF
--- a/jakartaee-api/pom.xml
+++ b/jakartaee-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>jakarta.platform</groupId>
         <artifactId>jakartaee-api-parent</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>10.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>jakarta.jakartaee-api</artifactId>
     <name>Jakarta EE Platform API</name>

--- a/jakartaee-bom/pom.xml
+++ b/jakartaee-bom/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>jakarta.platform</groupId>
         <artifactId>jakartaee-api-parent</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>10.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>jakarta.jakartaee-bom</artifactId>
     <packaging>pom</packaging>

--- a/jakartaee-core-api/pom.xml
+++ b/jakartaee-core-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>jakarta.platform</groupId>
         <artifactId>jakartaee-api-parent</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>10.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>jakarta.jakartaee-core-api</artifactId>
     <name>Jakarta EE Core Profile API</name>

--- a/jakartaee-web-api/pom.xml
+++ b/jakartaee-web-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>jakarta.platform</groupId>
         <artifactId>jakartaee-api-parent</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>10.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>jakarta.jakartaee-web-api</artifactId>
     <name>Jakarta EE Web Profile API</name>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
     <groupId>jakarta.platform</groupId>
     <artifactId>jakartaee-api-parent</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>10.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Jakarta EE API parent</name>
     <description>Jakarta EE API parent</description>


### PR DESCRIPTION
IMO branch `10.0.0-BRANCH`, for the lack of better candidate (I'd like to see `10.0.0-BRANCH` renamed to `10.0.x`) should produce next `10.0.x` artifacts, not `11.0.0`.