### PR TITLE
deps: Update Faces API, update javadoc modulepath for activation, etc

### DIFF
--- a/jakartaee-api/pom.xml
+++ b/jakartaee-api/pom.xml
@@ -183,23 +183,5 @@
                  </exclusion>
              </exclusions>
         </dependency>
-
-        <!-- Compile-time dependencies -->
-        <!-- work around for GLASSFISH-19861  -->
-        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.faces</artifactId>
-            <version>${mojarra.version}</version>
-            <optional>true</optional>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-
     </dependencies>
 </project>

--- a/jakartaee-core-api/pom.xml
+++ b/jakartaee-core-api/pom.xml
@@ -29,7 +29,7 @@
     <description>Jakarta EE Core Profile API</description>
 
     <properties>
-        <apidocs.modulepath>${jakarta.activation:jakarta.activation-api:jar}:${jakarta.xml.bind:jakarta.xml.bind-api:jar}:${jakarta.el:jakarta.el-api:jar}</apidocs.modulepath>
+        <apidocs.modulepath>${jakarta.xml.bind:jakarta.xml.bind-api:jar}:${jakarta.el:jakarta.el-api:jar}</apidocs.modulepath>
     </properties>
 
     <build>
@@ -152,19 +152,6 @@
             <version>${jakarta.enterprise.cdi-api.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
-            <version>${jakarta.activation-api.version}</version>
-            <optional>true</optional>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
         <!-- Only needed to compile the BeanManager non-Lite usage of EL -->
         <dependency>
             <groupId>jakarta.el</groupId>

--- a/jakartaee-web-api/pom.xml
+++ b/jakartaee-web-api/pom.xml
@@ -29,7 +29,7 @@
     <description>Jakarta EE Web Profile API</description>
 
     <properties>
-        <apidocs.modulepath>${jakarta.activation:jakarta.activation-api:jar}:${jakarta.el:jakarta.el-api:jar}:${jakarta.data:jakarta.data-api:jar}</apidocs.modulepath>
+        <apidocs.modulepath>${jakarta.el:jakarta.el-api:jar}:${jakarta.data:jakarta.data-api:jar}</apidocs.modulepath>
     </properties>
 
     <build>
@@ -252,26 +252,6 @@
             <groupId>jakarta.enterprise.concurrent</groupId>
             <artifactId>jakarta.enterprise.concurrent-api</artifactId>
             <version>${jakarta.enterprise.concurrent-api.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
-            <version>${jakarta.activation-api.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <!-- work around for GLASSFISH-19861  -->
-        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.faces</artifactId>
-            <version>${mojarra.version}</version>
-            <optional>true</optional>
-            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <jakarta.servlet-api.version>6.1.0</jakarta.servlet-api.version>
         <jakarta.servlet.jsp-api.version>4.0.0</jakarta.servlet.jsp-api.version>
         <jakarta.servlet.jsp.jstl-api.version>3.0.2</jakarta.servlet.jsp.jstl-api.version>
-        <jakarta.faces-api.version>4.1.1</jakarta.faces-api.version>
+        <jakarta.faces-api.version>4.1.2</jakarta.faces-api.version>
         <jakarta.el-api.version>6.0.1</jakarta.el-api.version>
         <jakarta.websocket-api.version>2.2.0</jakarta.websocket-api.version>
         <jakarta.ejb-api.version>4.0.1</jakarta.ejb-api.version>
@@ -94,9 +94,6 @@
 
         <!-- Other dependencies -->
         <copyright-plugin.version>1.50</copyright-plugin.version>
-
-        <!-- Compile-time dependencies -->
-        <mojarra.version>4.1.1</mojarra.version>
 
         <!-- Java compiler release (replaces source and target)-->
         <maven.compiler.release>17</maven.compiler.release>


### PR DESCRIPTION
- Update Faces API version to 4.1.2
- Remove work around for GLASSFISH-19861 since jakarta.faces-api includes com.sun.faces source in its sources jar
- Remove activation from modulepath for core and web and remove it as a dependency