### PR TITLE
Re-add mojarra to dependencies removed in #178

### DIFF
--- a/jakartaee-web-api/pom.xml
+++ b/jakartaee-web-api/pom.xml
@@ -259,5 +259,20 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <!-- work around for GLASSFISH-19861  -->
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.faces</artifactId>
+            <version>${mojarra.version}</version>
+            <optional>true</optional>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,9 @@
         <!-- Other dependencies -->
         <copyright-plugin.version>1.50</copyright-plugin.version>
 
+        <!-- Compile-time dependencies -->
+        <mojarra.version>4.1.2</mojarra.version>
+
         <!-- Java compiler release (replaces source and target)-->
         <maven.compiler.release>17</maven.compiler.release>
     </properties>


### PR DESCRIPTION
When building javadoc, mojarra still is needed in order to generate it.  It wasn't needed for other things so it was removed in #178, but javadoc was not attempted at that time.