### PR TITLE
Avoid inheritance of scm informations in poms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ pom.xml.releaseBackup
 pom.xml.next
 release.properties
 dependency-reduced-pom.xml
+.flattened-pom.xml

--- a/jakartaee-api/pom.xml
+++ b/jakartaee-api/pom.xml
@@ -32,6 +32,12 @@
         <maven.deploy.skip>${platform.deploy.skip}</maven.deploy.skip>
     </properties>
 
+    <scm>
+        <connection>scm:git:git@github.com:jakartaee/jakartaee-api</connection>
+        <developerConnection>scm:git:git@github.com:jakartaee/jakartaee-api</developerConnection>
+        <url>https://github.com/jakartaee/jakartaee-api/jakartaee-api</url>
+    </scm>
+
     <build>
         <plugins>
             <plugin>

--- a/jakartaee-api/pom.xml
+++ b/jakartaee-api/pom.xml
@@ -35,7 +35,7 @@
     <scm>
         <connection>scm:git:git@github.com:jakartaee/jakartaee-api</connection>
         <developerConnection>scm:git:git@github.com:jakartaee/jakartaee-api</developerConnection>
-        <url>https://github.com/jakartaee/jakartaee-api/jakartaee-api</url>
+        <url>https://github.com/jakartaee/jakartaee-api</url>
     </scm>
 
     <build>

--- a/jakartaee-bom/pom.xml
+++ b/jakartaee-bom/pom.xml
@@ -36,7 +36,7 @@
     <scm>
         <connection>scm:git:git@github.com:jakartaee/jakartaee-api</connection>
         <developerConnection>scm:git:git@github.com:jakartaee/jakartaee-api</developerConnection>
-        <url>https://github.com/jakartaee/jakartaee-api/jakartaee-bom</url>
+        <url>https://github.com/jakartaee/jakartaee-api</url>
     </scm>
 
     <build>

--- a/jakartaee-bom/pom.xml
+++ b/jakartaee-bom/pom.xml
@@ -33,6 +33,12 @@
         <maven.deploy.skip>${bom.deploy.skip}</maven.deploy.skip>
     </properties>
 
+    <scm>
+        <connection>scm:git:git@github.com:jakartaee/jakartaee-api</connection>
+        <developerConnection>scm:git:git@github.com:jakartaee/jakartaee-api</developerConnection>
+        <url>https://github.com/jakartaee/jakartaee-api/jakartaee-bom</url>
+    </scm>
+
     <build>
         <plugins>
             <plugin>

--- a/jakartaee-core-api/pom.xml
+++ b/jakartaee-core-api/pom.xml
@@ -33,6 +33,12 @@
         <maven.deploy.skip>${coreprofile.deploy.skip}</maven.deploy.skip>
     </properties>
 
+    <scm>
+        <connection>scm:git:git@github.com:jakartaee/jakartaee-api</connection>
+        <developerConnection>scm:git:git@github.com:jakartaee/jakartaee-api</developerConnection>
+        <url>https://github.com/jakartaee/jakartaee-api/jakartaee-core-api</url>
+    </scm>
+
     <build>
         <plugins>
             <plugin>

--- a/jakartaee-core-api/pom.xml
+++ b/jakartaee-core-api/pom.xml
@@ -36,7 +36,7 @@
     <scm>
         <connection>scm:git:git@github.com:jakartaee/jakartaee-api</connection>
         <developerConnection>scm:git:git@github.com:jakartaee/jakartaee-api</developerConnection>
-        <url>https://github.com/jakartaee/jakartaee-api/jakartaee-core-api</url>
+        <url>https://github.com/jakartaee/jakartaee-api</url>
     </scm>
 
     <build>

--- a/jakartaee-web-api/pom.xml
+++ b/jakartaee-web-api/pom.xml
@@ -33,6 +33,12 @@
         <maven.deploy.skip>${webprofile.deploy.skip}</maven.deploy.skip>
     </properties>
 
+    <scm>
+        <connection>scm:git:git@github.com:jakartaee/jakartaee-api</connection>
+        <developerConnection>scm:git:git@github.com:jakartaee/jakartaee-api</developerConnection>
+        <url>https://github.com/jakartaee/jakartaee-api/jakartaee-web-api</url>
+    </scm>
+
     <build>
         <plugins>
             <plugin>

--- a/jakartaee-web-api/pom.xml
+++ b/jakartaee-web-api/pom.xml
@@ -36,7 +36,7 @@
     <scm>
         <connection>scm:git:git@github.com:jakartaee/jakartaee-api</connection>
         <developerConnection>scm:git:git@github.com:jakartaee/jakartaee-api</developerConnection>
-        <url>https://github.com/jakartaee/jakartaee-api/jakartaee-web-api</url>
+        <url>https://github.com/jakartaee/jakartaee-api</url>
     </scm>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,16 @@
     <name>Jakarta EE API parent</name>
     <description>Jakarta EE API parent</description>
 
+    <scm>
+        <connection>scm:git:git@github.com:jakartaee/jakartaee-api</connection>
+        <developerConnection>scm:git:git@github.com:jakartaee/jakartaee-api</developerConnection>
+        <url>https://github.com/jakartaee/jakartaee-api</url>
+    </scm>
+    <issueManagement>
+        <system>GitHub Issues</system>
+        <url>https://github.com/jakartaee/jakartaee-api/issues</url>
+    </issueManagement>
+
     <modules>
         <module>jakartaee-bom</module>
         <module>jakartaee-core-api</module>


### PR DESCRIPTION
Currently deployed boms contains wrong scm informations.
Such https://repo.maven.apache.org/maven2/jakarta/platform/jakarta.jakartaee-bom/11.0.0/jakarta.jakartaee-bom-11.0.0.pom is containing
```
<scm>
<connection>scm:git:git@github.com:eclipse-ee4j/ee4j.git/jakartaee-api-parent/jakarta.jakartaee-bom</connection>
<developerConnection>scm:git:git@github.com:eclipse-ee4j/ee4j.git/jakartaee-api-parent/jakarta.jakartaee-bom</developerConnection>
<url>https://github.com/eclipse-ee4j/ee4j/jakartaee-api-parent/jakarta.jakartaee-bom</url>
</scm>
<issueManagement>
<system>GitHub Issues</system>
<url>https://github.com/eclipse-ee4j/ee4j/issues</url>
</issueManagement
```