### PR TITLE
Upgrade version to last available ee12 millestones

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,26 +87,26 @@
         <jakarta.ws.rs-api.version>4.0.0</jakarta.ws.rs-api.version>
 
         <!-- Web Profile -->
-        <jakarta.servlet-api.version>6.1.0</jakarta.servlet-api.version>
-        <jakarta.servlet.jsp-api.version>4.0.0</jakarta.servlet.jsp-api.version>
-        <jakarta.servlet.jsp.jstl-api.version>3.0.2</jakarta.servlet.jsp.jstl-api.version>
-        <jakarta.faces-api.version>4.1.2</jakarta.faces-api.version>
-        <jakarta.el-api.version>6.0.1</jakarta.el-api.version>
-        <jakarta.websocket-api.version>2.2.0</jakarta.websocket-api.version>
+        <jakarta.servlet-api.version>6.2.0-M2</jakarta.servlet-api.version>
+        <jakarta.servlet.jsp-api.version>4.1.0-M2</jakarta.servlet.jsp-api.version>
+        <jakarta.servlet.jsp.jstl-api.version>3.1.0-M1</jakarta.servlet.jsp.jstl-api.version>
+        <jakarta.faces-api.version>5.0.0-M2</jakarta.faces-api.version>
+        <jakarta.el-api.version>6.1.0-M2</jakarta.el-api.version>
+        <jakarta.websocket-api.version>2.3.0-M2</jakarta.websocket-api.version>
         <jakarta.ejb-api.version>4.0.1</jakarta.ejb-api.version>
         <jakarta.transaction-api.version>2.0.1</jakarta.transaction-api.version>
-        <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version>
-        <jakarta.validation-api.version>3.1.1</jakarta.validation-api.version>
+        <jakarta.persistence-api.version>4.0.0-M3</jakarta.persistence-api.version>
+        <jakarta.validation-api.version>4.0.0-M1</jakarta.validation-api.version>
         <jakarta.authentication-api.version>3.1.0</jakarta.authentication-api.version>
-        <jakarta.security.enterprise-api.version>4.0.0</jakarta.security.enterprise-api.version>
-        <jakarta.enterprise.concurrent-api.version>3.1.1</jakarta.enterprise.concurrent-api.version>
-        <jakarta.data.version>1.0.1</jakarta.data.version>
+        <jakarta.security.enterprise-api.version>5.0.0-M2</jakarta.security.enterprise-api.version>
+        <jakarta.enterprise.concurrent-api.version>3.2.0-M2</jakarta.enterprise.concurrent-api.version>
+        <jakarta.data.version>1.1.0-M3</jakarta.data.version>
         <jakarta.cdi-el-api.version>5.0.0.Beta1</jakarta.cdi-el-api.version>
 
         <!--  Platform -->
         <jakarta.jms-api.version>3.1.0</jakarta.jms-api.version>
-        <jakarta.activation-api.version>2.1.3</jakarta.activation-api.version>
-        <jakarta.mail-api.version>2.1.3</jakarta.mail-api.version>
+        <jakarta.activation-api.version>2.2.0-M2</jakarta.activation-api.version>
+        <jakarta.mail-api.version>2.2.0-M1</jakarta.mail-api.version>
         <jakarta.resource-api.version>2.1.0</jakarta.resource-api.version>
         <jakarta.authorization-api.version>3.0.0</jakarta.authorization-api.version>
         <jakarta.batch-api.version>2.1.1</jakarta.batch-api.version>


### PR DESCRIPTION
 
 | Property | Old Version | New Version |
 |---|---|---|
 | `jakarta.servlet-api.version` | 6.1.0 | **6.2.0-M2** |
 | `jakarta.servlet.jsp-api.version` | 4.0.0 | **4.1.0-M2** |
 | `jakarta.servlet.jsp.jstl-api.version` | 3.0.2 | **3.1.0-M1** |
 | `jakarta.faces-api.version` | 4.1.2 | **5.0.0-M2** |
 | `jakarta.el-api.version` | 6.0.1 | **6.1.0-M2** |
 | `jakarta.websocket-api.version` | 2.2.0 | **2.3.0-M2** |
 | `jakarta.persistence-api.version` | 3.2.0 | **4.0.0-M3** |
 | `jakarta.validation-api.version` | 3.1.1 | **4.0.0-M1** |
 | `jakarta.security.enterprise-api.version` | 4.0.0 | **5.0.0-M2** |
 | `jakarta.enterprise.concurrent-api.version` | 3.1.1 | **3.2.0-M2** |
 | `jakarta.data.version` | 1.0.1 | **1.1.0-M3** |
 | `jakarta.activation-api.version` | 2.1.3 | **2.2.0-M2** |
 | `jakarta.mail-api.version` | 2.1.3 | **2.2.0-M1** |
 
 ### Unchanged
 | Property | Version | Reason |
 |---|---|---|
 | `jakarta.inject.version` | 2.0.1 | Up to date |
 | `jakarta.json-api.version` | 2.1.3 | Up to date |
 | `jakarta.json.bind-api.version` | 3.0.1 | Up to date |
 | `jakarta.annotation-api.version` | 3.0.0 | Up to date |
 | `jakarta.interceptor-api.version` | 2.2.0 | Up to date |
 | `jakarta.cdi-api.version` | 5.0.0.Beta1 | Staging only |
 | `jakarta.cdi-el-api.version` | 5.0.0.Beta1 | Staging only |
 | `jakarta.ws.rs-api.version` | 4.0.0 | Up to date |
 | `jakarta.ejb-api.version` | 4.0.1 | Up to date |
 | `jakarta.transaction-api.version` | 2.0.1 | Up to date |
 | `jakarta.authentication-api.version` | 3.1.0 | Up to date |
 | `jakarta.jms-api.version` | 3.1.0 | Up to date |
 | `jakarta.resource-api.version` | 2.1.0 | Up to date |
 | `jakarta.authorization-api.version` | 3.0.0 | Up to date |
 | `jakarta.batch-api.version` | 2.1.1 | Up to date |

Signed-off-by: Olivier Lamy <olamy@apache.org>
